### PR TITLE
Fix a property name of list_emails function

### DIFF
--- a/recipes/use_cases/email_agent/functions_prompt.py
+++ b/recipes/use_cases/email_agent/functions_prompt.py
@@ -8,7 +8,7 @@ list_emails_function = """
             "type": "dic",
             "properties": [
                 {
-                    "maxResults": {
+                    "max_results": {
                         "type": "integer",
                         "description": "The default maximum number of emails to return is 100; the maximum allowed value for this field is 500."
                     }


### PR DESCRIPTION
# What does this PR do?

Property name `maxResults` should be renamed as `max_results`.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Please include a good title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

-->

<!-- Remove if not applicable -->


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
