### PR TITLE
Ignore HTTP response 429 during link check

### DIFF
--- a/.github/scripts/markdown_link_check_config.json
+++ b/.github/scripts/markdown_link_check_config.json
@@ -23,5 +23,6 @@
     {
       "pattern": "https://www.intel.com/content/www/us/en/developer/articles/news/llama2.html"
     }
-  ]
+  ],
+  "aliveStatusCodes": [429, 200]
 }


### PR DESCRIPTION
Ignore HTTP response error code 429: Too Many Requests when link-checking markdown files.

Some sites, such as Medium, return this error code even though the link is live. Presumably, Medium does this for "members-only" articles. Example:

https://betterprogramming.pub/text-to-audio-generation-with-bark-clearly-explained-4ee300a3713a

The 429 on the above article--which is a false positive--causes our linting to fail on the following file, which references that article:

`./end-to-end-use-cases/NotebookLlama/README.md`

Here is an example of this failure:

https://github.com/meta-llama/llama-cookbook/actions/runs/12954370628/job/36136168871?pr=866#step:4:226

See also:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429

## Feature/Issue validation/testing

This configuration change is shown in the following sample configuration file:

https://github.com/tcort/markdown-link-check#config-file-format


## Before submitting
- [NA] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [Y] Did you read the [contributor guideline](https://github.com/meta-llama/llama-cookbook/blob/main/CONTRIBUTING.md), Pull Request section?
- [NA] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [NA] Did you make sure to update the documentation with your changes?  
- [N] Did you write any new necessary tests?

Thanks for contributing 🎉!
