### PR TITLE
Llama4 Fine-tuning using torchtune

### DIFF
--- a/getting-started/finetuning/finetune_llama4.md
+++ b/getting-started/finetuning/finetune_llama4.md
@@ -4,10 +4,13 @@ This tutorial shows how to perform fine-tuning on Llama4 models using [torchtune
 
 ### Prerequisites
 
-1. We need to use torchtune to perform LoRA fine-tuning. Now llama4 LORA fine-tune requires nightly build:
+1. We need to use torchtune to perform LoRA fine-tuning. Now llama4 LORA fine-tune requires build from source and install pytorch nightly build.
 ```bash
-pip install --pre torchtune --extra-index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir
-pip install --pre torch torchvision torchao --index-url https://download.pytorch.org/whl/nightly/cu126
+pip install --force-reinstall --pre torch torchvision torchao --index-url https://download.pytorch.org/whl/nightly/cu126
+git clone https://github.com/pytorch/torchtune.git
+cd torchtune
+git checkout 1be43b6c3fc73e9bc5102bc53c4e70f849093bf6
+pip install -e .
 ```
 
 2. We also need Hugging Face access token (HF_TOKEN) for model download, please follow the instructions [here](https://huggingface.co/docs/hub/security-tokens) to get your own token. You will also need to gain model access to Llama4 models from [here](https://huggingface.co/collections/meta-llama/llama-4-67f0c30d9fe03840bc9d0164)
@@ -38,19 +41,16 @@ To run LoRA fine-tuning, use the following command:
 tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora
 ```
 
-This will run LoRA fine-tuning on Llama4 model with 8 GPUs.
+This will run LoRA fine-tuning on Llama4 model with 8 GPUs. The config llama4/scout_17B_16E_lora is a config file that specifies the model, tokenizer, and training parameters.
 
 You can add specific overrides through the command line. For example, to use a larger batch_size:
 
 ```bash
-  tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora batch_size=4 dataset.packed=True tokenizer.max_seq_len=2048
+  tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora batch_size=4 dataset.packed=True tokenizer.max_seq_len=2048 fsdp_cpu_offload=True
 ```
+The dataset.packed=True and tokenizer.max_seq_len=2048 are additional arguments that specify the dataset and tokenizer settings. By default, lora_finetune_distributed will not use CPU offloading, so set `fsdp_cpu_offload=True` will enable that to avoid OOM.  To learn more about the available options, please refer to the [YAML config documentation](https://pytorch.org/torchtune/stable/deep_dives/configs.html#config-tutorial-label)
 
-The config llama4/scout_17B_16E_lora is a config file that specifies the model, tokenizer, and training parameters. The dataset.packed=True and tokenizer.max_seq_len=2048 are additional arguments that specify the dataset and tokenizer settings. To learn more about the available options, please refer to the [YAML config documentation](https://pytorch.org/torchtune/stable/deep_dives/configs.html#config-tutorial-label)
-
-With this setup, you can efficiently train LoRA adapters on Llama4 models using torchtune’s native recipes.
-
-3. **Full Parameter Fine-Tuning for Llama4**
+3. **Run Full Parameter Fine-Tuning for Llama4**
 
 To run full parameter fine-tuning, use the following command:
 

--- a/getting-started/finetuning/finetune_llama4.md
+++ b/getting-started/finetuning/finetune_llama4.md
@@ -1,0 +1,49 @@
+## Fine-Tuning Tutorial for Llama4 Models with torchtune
+
+This tutorial shows how to perform Low-Rank Adaptation (LoRA) fine-tuning on Llama4 models using torchtune, based on the recent PR adding LoRA support for Llama4.
+
+### Prerequisites
+
+1. We need to use torchtune to perform LoRA fine-tuning. Now llama4 LORA fine-tune requires nightly build:
+```bash
+pip install --pre torchtune --extra-index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir
+```
+
+2. We also need Hugging Face access token (HF_TOKEN) for model download, please follow the instructions [here](https://huggingface.co/docs/hub/security-tokens) to get your own token.
+
+### Tutorial
+1. Download Llama4 Weights
+Replace <HF_TOKEN> with your Hugging Face token:
+
+```bash
+tune download meta-llama/Llama-4-Scout-17B-16E-Instruct --output-dir /tmp/Llama-4-Scout-17B-16E-Instruct --hf-token $HF_TOKEN
+```
+
+Alternatively, you can use `huggingface-cli` to login then download the model weights.
+```bash
+huggingface-cli login --token $HF_TOKEN
+tune download meta-llama/Llama-4-Scout-17B-16E-Instruct --output-dir /tmp/Llama-4-Scout-17B-16E-Instruct
+```
+This retrieves the model weights, tokenizer from Hugging Face.
+
+2. Run LoRA Fine-Tuning for Llama4
+To run LoRA fine-tuning, use the following command:
+```bash
+tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora
+```
+You can add specific overrides through the command line. For example, to use a larger batch_size:
+```bash
+  tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora batch_size=4 dataset.packed=True tokenizer.max_seq_len=2048
+```
+This will run LoRA fine-tuning on Llama4 model with 8 GPUs. It will requires around 400GB gpu memory to do Scout lora fine-tuning.
+
+The config llama4/scout_17B_16E_lora is a config file that specifies the model, tokenizer, and training parameters. The dataset.packed=True and tokenizer.max_seq_len=2048 are additional arguments that specify the dataset and tokenizer settings.To learn more about the available options, please refer to the [YAML config documentation](https://pytorch.org/torchtune/stable/deep_dives/configs.html#config-tutorial-label)
+
+With this setup, you can efficiently train LoRA adapters on Llama4 models using torchtune’s native recipes.
+
+3. Full Parameter Fine-Tuning for Llama4 (Optional)
+To run full parameter fine-tuning, use the following command:
+```bash
+  tune run --nproc_per_node 4  --nproc_per_node 8 full_finetune_distributed --config llama4/scout_17B_16E_full batch_size=4 dataset.packed=True tokenizer.max_seq_len=2048
+  ```
+This will run full parameter fine-tuning on Llama4 model with 8 GPUs. It will requires around 2200GB gpu memory to do Scout full parameter fine-tuning, which is about 4 8xH100 nodes.

--- a/getting-started/finetuning/finetune_llama4.md
+++ b/getting-started/finetuning/finetune_llama4.md
@@ -12,7 +12,8 @@ pip install --pre torchtune --extra-index-url https://download.pytorch.org/whl/n
 2. We also need Hugging Face access token (HF_TOKEN) for model download, please follow the instructions [here](https://huggingface.co/docs/hub/security-tokens) to get your own token. You will also need to gain model access to Llama4 models from [here](https://huggingface.co/collections/meta-llama/llama-4-67f0c30d9fe03840bc9d0164)
 
 ### Steps
-1. Download Llama4 Weights
+1. **Download Llama4 Weights**
+
 We will use `meta-llama/Llama-4-Scout-17B-16E-Instruct` as an example here. Replace <HF_TOKEN> with your Hugging Face token:
 
 ```bash
@@ -20,18 +21,22 @@ tune download meta-llama/Llama-4-Scout-17B-16E-Instruct --output-dir /tmp/Llama-
 ```
 
 Alternatively, you can use `huggingface-cli` to login then download the model weights.
+
 ```bash
 huggingface-cli login --token $HF_TOKEN
 tune download meta-llama/Llama-4-Scout-17B-16E-Instruct --output-dir /tmp/Llama-4-Scout-17B-16E-Instruct
 ```
+
 This retrieves the model weights, tokenizer from Hugging Face.
 
-2. Run LoRA Fine-Tuning for Llama4
+2. **Run LoRA Fine-Tuning for Llama4**
 
 To run LoRA fine-tuning, use the following command:
+
 ```bash
 tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora
 ```
+
 This will run LoRA fine-tuning on Llama4 model with 8 GPUs. It will requires around 400GB gpu memory to do Llama4 Scout LoRA fine-tuning.
 
 You can add specific overrides through the command line. For example, to use a larger batch_size:
@@ -44,7 +49,7 @@ The config llama4/scout_17B_16E_lora is a config file that specifies the model, 
 
 With this setup, you can efficiently train LoRA adapters on Llama4 models using torchtune’s native recipes.
 
-3. Full Parameter Fine-Tuning for Llama4
+3. **Full Parameter Fine-Tuning for Llama4**
 
 To run full parameter fine-tuning, use the following command:
 

--- a/getting-started/finetuning/finetune_llama4.md
+++ b/getting-started/finetuning/finetune_llama4.md
@@ -9,7 +9,7 @@ This tutorial shows how to perform fine-tuning on Llama4 models using [torchtune
 pip install --force-reinstall --pre torch torchvision torchao --index-url https://download.pytorch.org/whl/nightly/cu126
 git clone https://github.com/pytorch/torchtune.git
 cd torchtune
-git checkout 1be43b6c3fc73e9bc5102bc53c4e70f849093bf6
+git checkout 5d51c25cedfb6ba7b00e03cb2fef4f9cdb7baebd
 pip install -e .
 ```
 

--- a/getting-started/finetuning/finetune_llama4.md
+++ b/getting-started/finetuning/finetune_llama4.md
@@ -7,6 +7,7 @@ This tutorial shows how to perform fine-tuning on Llama4 models using [torchtune
 1. We need to use torchtune to perform LoRA fine-tuning. Now llama4 LORA fine-tune requires nightly build:
 ```bash
 pip install --pre torchtune --extra-index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir
+pip install --pre torch torchvision torchao --index-url https://download.pytorch.org/whl/nightly/cu126
 ```
 
 2. We also need Hugging Face access token (HF_TOKEN) for model download, please follow the instructions [here](https://huggingface.co/docs/hub/security-tokens) to get your own token. You will also need to gain model access to Llama4 models from [here](https://huggingface.co/collections/meta-llama/llama-4-67f0c30d9fe03840bc9d0164)
@@ -37,7 +38,7 @@ To run LoRA fine-tuning, use the following command:
 tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora
 ```
 
-This will run LoRA fine-tuning on Llama4 model with 8 GPUs. It will requires around 400GB gpu memory to do Llama4 Scout LoRA fine-tuning.
+This will run LoRA fine-tuning on Llama4 model with 8 GPUs.
 
 You can add specific overrides through the command line. For example, to use a larger batch_size:
 
@@ -54,7 +55,9 @@ With this setup, you can efficiently train LoRA adapters on Llama4 models using 
 To run full parameter fine-tuning, use the following command:
 
 ```bash
-  tune run --nproc_per_node 4  --nproc_per_node 8 full_finetune_distributed --config llama4/scout_17B_16E_full batch_size=4 dataset.packed=True tokenizer.max_seq_len=2048
+  tune run  --nproc_per_node 8 full_finetune_distributed --config llama4/scout_17B_16E_full batch_size=4 dataset.packed=True tokenizer.max_seq_len=2048
   ```
 
-This will run full parameter fine-tuning on Llama4 model with 4 nodes. It will requires around 2200GB gpu memory to do Scout full parameter fine-tuning, which is about 4 8xH100 nodes.
+This command will run a full fine-tuning on a single node as Torchtune by default use CPU offload to avoid Out-of-Memory (OOM) error.
+
+Alternatively, if you want to run with multi-node to avoid possible slowness from CPU offloading, please modify this [slurm script](https://github.com/pytorch/torchtune/blob/0ddd4b93c83de60656fb3db738228b06531f7c1e/recipes/full_finetune_multinode.slurm#L39).

--- a/getting-started/finetuning/finetune_llama4.md
+++ b/getting-started/finetuning/finetune_llama4.md
@@ -48,7 +48,7 @@ You can add specific overrides through the command line. For example, to use a l
 ```bash
   tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora batch_size=4 dataset.packed=True tokenizer.max_seq_len=2048 fsdp_cpu_offload=True
 ```
-The dataset.packed=True and tokenizer.max_seq_len=2048 are additional arguments that specify the dataset and tokenizer settings. By default, lora_finetune_distributed will not use CPU offloading, so set `fsdp_cpu_offload=True` will enable that to avoid OOM.  To learn more about the available options, please refer to the [YAML config documentation](https://pytorch.org/torchtune/stable/deep_dives/configs.html#config-tutorial-label)
+The dataset.packed=True and tokenizer.max_seq_len=2048 are additional arguments that specify the dataset and tokenizer settings. By default, lora_finetune_distributed will not use CPU offloading, so set `fsdp_cpu_offload=True` will enable that to avoid OOM. Please check the [this yaml](https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama4/scout_17B_16E_lora.yaml) for all the possible configs to override. To learn more about the YAML config, please refer to the [YAML config documentation](https://pytorch.org/torchtune/stable/deep_dives/configs.html#config-tutorial-label)
 
 3. **Run Full Parameter Fine-Tuning for Llama4**
 
@@ -58,6 +58,6 @@ To run full parameter fine-tuning, use the following command:
   tune run  --nproc_per_node 8 full_finetune_distributed --config llama4/scout_17B_16E_full batch_size=4 dataset.packed=True tokenizer.max_seq_len=2048
   ```
 
-This command will run a full fine-tuning on a single node as Torchtune by default use CPU offload to avoid Out-of-Memory (OOM) error.
+This command will run a full fine-tuning on a single node as Torchtune by default use CPU offload to avoid Out-of-Memory (OOM) error. Please check the [this yaml](https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama4/scout_17B_16E_full.yaml) for all the possible configs to override.
 
 Alternatively, if you want to run with multi-node to avoid possible slowness from CPU offloading, please modify this [slurm script](https://github.com/pytorch/torchtune/blob/0ddd4b93c83de60656fb3db738228b06531f7c1e/recipes/full_finetune_multinode.slurm#L39).

--- a/getting-started/finetuning/finetune_llama4.md
+++ b/getting-started/finetuning/finetune_llama4.md
@@ -1,6 +1,6 @@
 ## Fine-Tuning Tutorial for Llama4 Models with torchtune
 
-This tutorial shows how to perform Low-Rank Adaptation (LoRA) fine-tuning on Llama4 models using torchtune, based on the recent PR adding LoRA support for Llama4.
+This tutorial shows how to perform fine-tuning on Llama4 models using [torchtune](https://github.com/pytorch/torchtune?tab=readme-ov-file).
 
 ### Prerequisites
 
@@ -9,11 +9,11 @@ This tutorial shows how to perform Low-Rank Adaptation (LoRA) fine-tuning on Lla
 pip install --pre torchtune --extra-index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir
 ```
 
-2. We also need Hugging Face access token (HF_TOKEN) for model download, please follow the instructions [here](https://huggingface.co/docs/hub/security-tokens) to get your own token.
+2. We also need Hugging Face access token (HF_TOKEN) for model download, please follow the instructions [here](https://huggingface.co/docs/hub/security-tokens) to get your own token. You will also need to gain model access to Llama4 models from [here](https://huggingface.co/collections/meta-llama/llama-4-67f0c30d9fe03840bc9d0164)
 
-### Tutorial
+### Steps
 1. Download Llama4 Weights
-Replace <HF_TOKEN> with your Hugging Face token:
+We will use `meta-llama/Llama-4-Scout-17B-16E-Instruct` as an example here. Replace <HF_TOKEN> with your Hugging Face token:
 
 ```bash
 tune download meta-llama/Llama-4-Scout-17B-16E-Instruct --output-dir /tmp/Llama-4-Scout-17B-16E-Instruct --hf-token $HF_TOKEN
@@ -27,23 +27,29 @@ tune download meta-llama/Llama-4-Scout-17B-16E-Instruct --output-dir /tmp/Llama-
 This retrieves the model weights, tokenizer from Hugging Face.
 
 2. Run LoRA Fine-Tuning for Llama4
+
 To run LoRA fine-tuning, use the following command:
 ```bash
 tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora
 ```
+This will run LoRA fine-tuning on Llama4 model with 8 GPUs. It will requires around 400GB gpu memory to do Llama4 Scout LoRA fine-tuning.
+
 You can add specific overrides through the command line. For example, to use a larger batch_size:
+
 ```bash
   tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora batch_size=4 dataset.packed=True tokenizer.max_seq_len=2048
 ```
-This will run LoRA fine-tuning on Llama4 model with 8 GPUs. It will requires around 400GB gpu memory to do Scout lora fine-tuning.
 
-The config llama4/scout_17B_16E_lora is a config file that specifies the model, tokenizer, and training parameters. The dataset.packed=True and tokenizer.max_seq_len=2048 are additional arguments that specify the dataset and tokenizer settings.To learn more about the available options, please refer to the [YAML config documentation](https://pytorch.org/torchtune/stable/deep_dives/configs.html#config-tutorial-label)
+The config llama4/scout_17B_16E_lora is a config file that specifies the model, tokenizer, and training parameters. The dataset.packed=True and tokenizer.max_seq_len=2048 are additional arguments that specify the dataset and tokenizer settings. To learn more about the available options, please refer to the [YAML config documentation](https://pytorch.org/torchtune/stable/deep_dives/configs.html#config-tutorial-label)
 
 With this setup, you can efficiently train LoRA adapters on Llama4 models using torchtune’s native recipes.
 
-3. Full Parameter Fine-Tuning for Llama4 (Optional)
+3. Full Parameter Fine-Tuning for Llama4
+
 To run full parameter fine-tuning, use the following command:
+
 ```bash
   tune run --nproc_per_node 4  --nproc_per_node 8 full_finetune_distributed --config llama4/scout_17B_16E_full batch_size=4 dataset.packed=True tokenizer.max_seq_len=2048
   ```
-This will run full parameter fine-tuning on Llama4 model with 8 GPUs. It will requires around 2200GB gpu memory to do Scout full parameter fine-tuning, which is about 4 8xH100 nodes.
+
+This will run full parameter fine-tuning on Llama4 model with 4 nodes. It will requires around 2200GB gpu memory to do Scout full parameter fine-tuning, which is about 4 8xH100 nodes.

--- a/getting-started/finetuning/finetune_llama4.md
+++ b/getting-started/finetuning/finetune_llama4.md
@@ -41,16 +41,17 @@ To run LoRA fine-tuning, use the following command:
 tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora
 ```
 
-This will run LoRA fine-tuning on Llama4 model with 8 GPUs. The config llama4/scout_17B_16E_lora is a config file that specifies the model, tokenizer, and training parameters.
+This will run LoRA fine-tuning on Llama4 model with 8 GPUs. The config llama4/scout_17B_16E_lora is a config file that specifies the model, tokenizer, and training parameters. This command will also download the `alpaca_dataset` as selected in the [config file](https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama4/scout_17B_16E_full.yaml#L46). Please refer to the [Datasets section](https://pytorch.org/torchtune/main/basics/datasets_overview.html#datasets-overview) for more details.
 
 You can add specific overrides through the command line. For example, to use a larger batch_size:
 
 ```bash
   tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora batch_size=4 dataset.packed=True tokenizer.max_seq_len=2048 fsdp_cpu_offload=True
 ```
-The dataset.packed=True and tokenizer.max_seq_len=2048 are additional arguments that specify the dataset and tokenizer settings. By default, lora_finetune_distributed will not use CPU offloading, so set `fsdp_cpu_offload=True` will enable that to avoid OOM. Please check the [this yaml](https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama4/scout_17B_16E_lora.yaml) for all the possible configs to override. To learn more about the YAML config, please refer to the [YAML config documentation](https://pytorch.org/torchtune/stable/deep_dives/configs.html#config-tutorial-label)
+The `dataset.packed=True` and `tokenizer.max_seq_len=2048` are additional arguments that specify the dataset and tokenizer settings. By default, `lora_finetune_distributed` will not use CPU offloading, so set `fsdp_cpu_offload=True` will enable that to avoid OOM. Please check the [this yaml](https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama4/scout_17B_16E_lora.yaml) for all the possible configs to override. To learn more about the YAML config, please refer to the [YAML config documentation](https://pytorch.org/torchtune/stable/deep_dives/configs.html#config-tutorial-label)
 
 3. **Run Full Parameter Fine-Tuning for Llama4**
+
 
 To run full parameter fine-tuning, use the following command:
 


### PR DESCRIPTION
# What does this PR do?
Add Llama4 Fine-tuning recipe using torchtune

<!-- Remove if not applicable -->

Fixes # (issue)


## Feature/Issue validation/testing

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] H100 test log
```
tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora batch_size=4 dataset.packed=True tokenizer.max_seq_len=2048 max_steps_per_epoch=5
INFO:torchtune.utils._logging:Running LoRAFinetuneRecipeDistributed with resolved config:

batch_size: 4
checkpointer:
  _component_: torchtune.training.FullModelHFCheckpointer
  checkpoint_dir: /tmp/Llama-4-Scout-17B-16E-Instruct
  checkpoint_files:
    filename_format: model-{}-of-{}.safetensors
    max_filename: '00050'
  model_type: LLAMA4
  output_dir: /tmp/torchtune/llama4_17Bx16E/lora
  recipe_checkpoint: null
clip_grad_norm: null
compile: false
custom_sharded_layers:
- tok_embeddings
dataset:
  _component_: torchtune.datasets.alpaca_dataset
  packed: true
device: cuda
dtype: bf16
enable_activation_checkpointing: true
enable_activation_offloading: false
epochs: 1
fsdp_cpu_offload: false
gradient_accumulation_steps: 1
log_every_n_steps: 1
log_peak_memory_stats: true
loss:
  _component_: torchtune.modules.loss.LinearCrossEntropyLoss
lr_scheduler:
  _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
  num_warmup_steps: 100
max_steps_per_epoch: 5
metric_logger:
  _component_: torchtune.training.metric_logging.DiskLogger
  log_dir: /tmp/torchtune/llama4_17Bx16E/lora/logs
model:
  _component_: torchtune.models.llama4.lora_llama4_scout_17b_16e
  apply_lora_to_mlp: true
  apply_lora_to_output: false
  decoder_trainable: lora
  encoder_trainable: frozen
  fusion_trainable: lora
  lora_alpha: 32
  lora_attn_modules:
  - q_proj
  - v_proj
  - output_proj
  lora_dropout: 0.0
  lora_rank: 16
optimizer:
  _component_: torch.optim.AdamW
  fused: false
  lr: 2.0e-05
optimizer_in_bwd: false
output_dir: /tmp/torchtune/llama4_17Bx16E/lora
profiler:
  _component_: torchtune.training.setup_torch_profiler
  enabled: false
resume_from_checkpoint: false
save_adapter_weights_only: true
seed: null
shuffle: true
tokenizer:
  _component_: torchtune.models.llama4.llama4_transform
  max_num_tiles: 16
  max_seq_len: 2048
  path: /tmp/Llama-4-Scout-17B-16E-Instruct/tokenizer.model

NCCL version 2.26.2+cuda12.2
DEBUG:torchtune.utils._logging:Setting manual seed to local seed 355260077. Local seed is seed + rank = 355260077 + 0
INFO:torchtune.utils._logging:Hint: enable_activation_checkpointing is True, but enable_activation_offloading isn't. Enabling activation offloading should reduce memory further.
Writing logs to /tmp/torchtune/llama4_17Bx16E/lora/logs/log_1746214657.txt
INFO:torchtune.utils._logging:FSDP is enabled. Instantiating model and loading checkpoint on Rank 0 ...
/home/kaiwu/work/llama4/torchtune/recipes/lora_finetune_distributed.py:549: FutureWarning: lora_attn_modules is deprecated for validate_missing_and_unexpected_for_lora and will be removed in future versions. Please use state_dict_keys instead.
  validate_missing_and_unexpected_for_lora(
/home/kaiwu/work/llama4/torchtune/torchtune/utils/_logging.py:143: FutureWarning: apply_lora_to_mlp is deprecated for validate_missing_and_unexpected_for_lora and will be removed in future versions. Please use state_dict_keys instead.
  return obj(*args, **kwargs)
/home/kaiwu/work/llama4/torchtune/torchtune/utils/_logging.py:143: FutureWarning: apply_lora_to_output is deprecated for validate_missing_and_unexpected_for_lora and will be removed in future versions. Please use state_dict_keys instead.
  return obj(*args, **kwargs)
INFO:torchtune.utils._logging:Instantiating model and loading checkpoint took 99.66 secs
INFO:torchtune.utils._logging:Memory stats after model init:
        GPU peak memory active: 54.86 GiB
        GPU peak memory alloc: 54.86 GiB
        GPU peak memory reserved: 56.06 GiB
INFO:torchtune.utils._logging:Optimizer is initialized.
INFO:torchtune.utils._logging:Loss is initialized.
Packing dataset: 100%|██████████████████████████████████████████████████████████████| 52002/52002 [00:12<00:00, 4196.77it/s]
INFO:torchtune.utils._logging:Learning rate scheduler is initialized.
WARNING:torchtune.utils._logging: Profiling disabled.
INFO:torchtune.utils._logging: Profiler config after instantiation: {'enabled': False}
  0%|                                                                                                 | 0/5 [00:00<?, ?it/s]DEBUG:torchtune.utils._logging:Using flex attention for attention computation since a BlockMask was passed in.
1|5|Loss: 4.027358531951904: 100%|████████████████████████████████████████████████████████████| 5/5 [00:40<00:00,  7.18s/it]INFO:torchtune.utils._logging:Saving checkpoint. This may take some time. Retrieving full model state dict...
INFO:torchtune.utils._logging:Getting full model state dict took 90.95 secs
INFO:torchtune.utils._logging:Adapter checkpoint of size 1.01 GiB saved to /tmp/torchtune/llama4_17Bx16E/lora/epoch_0/adapter_model.pt
WARNING:torchtune.utils._logging:Saving Llama4 adapter weights to PEFT format is not supported, saving to torchtune format instead
INFO:torchtune.utils._logging:Adapter checkpoint of size 0.00 GiB saved to /tmp/torchtune/llama4_17Bx16E/lora/epoch_0/adapter_config.json
INFO:torchtune.utils._logging:Saving final epoch checkpoint.
INFO:torchtune.utils._logging:Please note that you have set adapter_only=True, so only adapter weights will be saved.You need to merge the adapter weights into your base model for further use. See FullModelHFCheckpointer.save_checkpoint for more details.
INFO:torchtune.utils._logging:Saving checkpoint took 0.62 secs
1|5|Loss: 4.027358531951904: 100%|████████████████████████████████████████████████████████████| 5/5 [02:11<00:00, 26.33s/it]
```
- [x] A100 Test Log with CPU off-load
```
INFO:torchtune.utils._logging:Running LoRAFinetuneRecipeDistributed with resolved config:

batch_size: 1
checkpointer:
  _component_: torchtune.training.FullModelHFCheckpointer
  checkpoint_dir: /tmp/Llama-4-Scout-17B-16E-Instruct
  checkpoint_files:
    filename_format: model-{}-of-{}.safetensors
    max_filename: '00050'
  model_type: LLAMA4
  output_dir: /tmp/torchtune/llama4_17Bx16E/lora
  recipe_checkpoint: null
clip_grad_norm: null
compile: false
custom_sharded_layers:
- tok_embeddings
dataset:
  _component_: torchtune.datasets.alpaca_dataset
  packed: true
device: cuda
dtype: bf16
enable_activation_checkpointing: true
enable_activation_offloading: false
epochs: 1
fsdp_cpu_offload: true
gradient_accumulation_steps: 1
log_every_n_steps: 1
log_peak_memory_stats: true
loss:
  _component_: torchtune.modules.loss.LinearCrossEntropyLoss
lr_scheduler:
  _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
  num_warmup_steps: 100
max_steps_per_epoch: 5
metric_logger:
  _component_: torchtune.training.metric_logging.DiskLogger
  log_dir: /tmp/torchtune/llama4_17Bx16E/lora/logs
model:
  _component_: torchtune.models.llama4.lora_llama4_scout_17b_16e
  apply_lora_to_mlp: true
  apply_lora_to_output: false
  decoder_trainable: lora
  encoder_trainable: frozen
  fusion_trainable: lora
  lora_alpha: 32
  lora_attn_modules:
  - q_proj
  - v_proj
  - output_proj
  lora_dropout: 0.0
  lora_rank: 16
optimizer:
  _component_: torch.optim.AdamW
  fused: false
  lr: 2.0e-05
optimizer_in_bwd: false
output_dir: /tmp/torchtune/llama4_17Bx16E/lora
profiler:
  _component_: torchtune.training.setup_torch_profiler
  enabled: false
resume_from_checkpoint: false
save_adapter_weights_only: true
seed: null
shuffle: true
tokenizer:
  _component_: torchtune.models.llama4.llama4_transform
  max_num_tiles: 16
  max_seq_len: 1024
  path: /tmp/Llama-4-Scout-17B-16E-Instruct/tokenizer.model

DEBUG:torchtune.utils._logging:Setting manual seed to local seed 3712560434. Local seed is seed + rank = 3712560434 + 0
INFO:torchtune.utils._logging:Hint: enable_activation_checkpointing is True, but enable_activation_offloading isn't. Enabling activation offloading should reduce memory further.
Writing logs to /tmp/torchtune/llama4_17Bx16E/lora/logs/log_1746215549.txt
INFO:torchtune.utils._logging:FSDP is enabled. Instantiating model and loading checkpoint on Rank 0 ...
NCCL version 2.26.2+cuda12.2
/home/kaiwu/.conda/envs/torchtune/lib/python3.10/site-packages/recipes/lora_finetune_distributed.py:549: FutureWarning: lora_attn_modules is deprecated for validate_missing_and_unexpected_for_lora and will be removed in future versions. Please use state_dict_keys instead.
  validate_missing_and_unexpected_for_lora(
/home/kaiwu/.conda/envs/torchtune/lib/python3.10/site-packages/torchtune/utils/_logging.py:143: FutureWarning: apply_lora_to_mlp is deprecated for validate_missing_and_unexpected_for_lora and will be removed in future versions. Please use state_dict_keys instead.
  return obj(*args, **kwargs)
/home/kaiwu/.conda/envs/torchtune/lib/python3.10/site-packages/torchtune/utils/_logging.py:143: FutureWarning: apply_lora_to_output is deprecated for validate_missing_and_unexpected_for_lora and will be removed in future versions. Please use state_dict_keys instead.
  return obj(*args, **kwargs)
INFO:torchtune.utils._logging:Instantiating model and loading checkpoint took 488.07 secs
INFO:torchtune.utils._logging:Memory stats after model init:
        GPU peak memory active: 12.54 GiB
        GPU peak memory alloc: 12.54 GiB
        GPU peak memory reserved: 12.55 GiB
INFO:torchtune.utils._logging:Optimizer is initialized.
INFO:torchtune.utils._logging:Loss is initialized.
Packing dataset: 100%|██████████████████████████████████████████████████████████████| 52002/52002 [00:29<00:00, 1779.69it/s]
INFO:torchtune.utils._logging:Learning rate scheduler is initialized.
WARNING:torchtune.utils._logging: Profiling disabled.
INFO:torchtune.utils._logging: Profiler config after instantiation: {'enabled': False}
  0%|                                                                                                 | 0/5 [00:00<?, ?it/s]DEBUG:torchtune.utils._logging:Using flex attention for attention computation since a BlockMask was passed in.
1|5|Loss: 3.9630274772644043: 100%|███████████████████████████████████████████████████████████| 5/5 [01:22<00:00, 15.79s/it]INFO:torchtune.utils._logging:Saving checkpoint. This may take some time. Retrieving full model state dict...
INFO:torchtune.utils._logging:Getting full model state dict took 312.65 secs
INFO:torchtune.utils._logging:Adapter checkpoint of size 1.01 GiB saved to /tmp/torchtune/llama4_17Bx16E/lora/epoch_0/adapter_model.pt
WARNING:torchtune.utils._logging:Saving Llama4 adapter weights to PEFT format is not supported, saving to torchtune format instead
INFO:torchtune.utils._logging:Adapter checkpoint of size 0.00 GiB saved to /tmp/torchtune/llama4_17Bx16E/lora/epoch_0/adapter_config.json
INFO:torchtune.utils._logging:Saving final epoch checkpoint.
INFO:torchtune.utils._logging:Please note that you have set adapter_only=True, so only adapter weights will be saved.You need to merge the adapter weights into your base model for further use. See FullModelHFCheckpointer.save_checkpoint for more details.
INFO:torchtune.utils._logging:Saving checkpoint took 1.36 secs
1|5|Loss: 3.9630274772644043: 100%|███████████████████████████████████████████████████████████| 5/5 [06:36<00:00, 79.26s/it]
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/meta-llama/llama-cookbook/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
