### PR TITLE
[Hotfix] Pytest Workflow AndroidManifest.xml issue

### DIFF
--- a/.github/workflows/pytest_cpu_gha_runner.yaml
+++ b/.github/workflows/pytest_cpu_gha_runner.yaml
@@ -70,5 +70,7 @@ jobs:
         id: test_summary
         uses: test-summary/action@v2
         with:
-          paths: "**/*.xml(?<!AndroidManifest\.xml)"
+          paths: |
+            **/*.xml
+            !**/AndroidManifest.xml
         if: always()


### PR DESCRIPTION
# Overview
This pull request updates the `paths` configuration in the `pytest_cpu_gha_runner.yaml` workflow file to improve the clarity and accuracy of test result file matching.

* [`.github/workflows/pytest_cpu_gha_runner.yaml`](diffhunk://#diff-7b508c3574b2f561060c23bcdde5f867f232043965d36a131f09b8c0b3b01f81L73-R75): Modified the `paths` parameter in the `test-summary` action to use a more explicit multi-line format. This ensures all `.xml` files are matched except for `AndroidManifest.xml`, improving readability and maintainability.
This solution worked well when we delivered at the first time, but it caused grammar errors during pytest.

## Problem
Riandy and I implemented the `AndroidManifest.xml` exception case for AndroidApp example.  
```
Error: unknown test file type for 'getting-started/demo/ArticleSummarizer/app/src/main/AndroidManifest.xml'
```

So, we changed the `pytest_cpu_gha_runner.yaml` [xml related paths](https://github.com/meta-llama/llama-cookbook/blob/b374b017603a6e955909e7848b07225bde0a1e33/.github/workflows/pytest_cpu_gha_runner.yaml#L73).
```
paths: "**/*.xml" --> paths: "**/*.xml(?<!AndroidManifest\.xml)"
```

## Solution

```
paths: **/*.xml !**/AndroidManifest.xml
```

