### PR TITLE
Fix model string name for Llama-Prompt-Guard-2-86M in inference.py

### DIFF
--- a/getting-started/responsible_ai/prompt_guard/inference.py
+++ b/getting-started/responsible_ai/prompt_guard/inference.py
@@ -23,7 +23,7 @@ DEFAULT_MODEL_NAME = "meta-llama/Llama-Prompt-Guard-2-86M"
 
 
 def load_model_and_tokenizer(
-    model_name: str = "meta-llama/Prompt-Guard-2-86M", device: str = DEFAULT_DEVICE
+    model_name: str = "meta-llama/Llama-Prompt-Guard-2-86M", device: str = DEFAULT_DEVICE
 ) -> Tuple[AutoModelForSequenceClassification, AutoTokenizer, str]:
     """
     Load the PromptGuard model and tokenizer, and move the model to the specified device.


### PR DESCRIPTION
getting-started/responsible_ai/prompt_guard/inference.py has the incorrect model string for Prompt Guard 2. It's correct here

https://github.com/meta-llama/llama-cookbook/blob/7dab6a3298ec2e4742283670b56b6d405bafb54d/getting-started/responsible_ai/prompt_guard/inference.py#L22

but wrong here

https://github.com/meta-llama/llama-cookbook/blob/7dab6a3298ec2e4742283670b56b6d405bafb54d/getting-started/responsible_ai/prompt_guard/inference.py#L26