### PR TITLE
Create readme to point to new dirs

### DIFF
--- a/recipes/quickstart/NotebookLlama/README.md
+++ b/recipes/quickstart/NotebookLlama/README.md
@@ -1,0 +1,8 @@
+## Notebook Llama
+
+This recipe has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/end-to-end-use-cases/NotebookLlama).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/quickstart/RAG/README.md
+++ b/recipes/quickstart/RAG/README.md
@@ -1,0 +1,8 @@
+## RAG Guide
+
+This guide has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/getting-started/RAG).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/quickstart/README.md
+++ b/recipes/quickstart/README.md
@@ -1,0 +1,8 @@
+## Quickstart Guide
+
+This directory has moved to [here](https://github.com/meta-llama/llama-cookbook/tree/main/getting-started).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/quickstart/agents/Agents_Tutorial/README.md
+++ b/recipes/quickstart/agents/Agents_Tutorial/README.md
@@ -1,0 +1,8 @@
+## Agents Tutorial
+
+This tutorial has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/end-to-end-use-cases/agents/Agents_Tutorial).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/quickstart/agents/DeepLearningai_Course_Notebooks/README.md
+++ b/recipes/quickstart/agents/DeepLearningai_Course_Notebooks/README.md
@@ -1,0 +1,8 @@
+## DeepLearning AI Course Notebooks
+
+These notebooks have moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/end-to-end-use-cases/agents/DeepLearningai_Course_Notebooks).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/quickstart/finetuning/README.md
+++ b/recipes/quickstart/finetuning/README.md
@@ -1,0 +1,8 @@
+## Finetuning Guide
+
+This guide has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/getting-started/finetuning).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/quickstart/inference/README.md
+++ b/recipes/quickstart/inference/README.md
@@ -1,0 +1,8 @@
+## Inference Guide
+
+This guide has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/getting-started/inference).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/responsible_ai/llama_guard/README.md
+++ b/recipes/responsible_ai/llama_guard/README.md
@@ -1,0 +1,8 @@
+## Llama Guard Guide
+
+This guide has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/getting-started/responsible_ai/llama_guard).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/responsible_ai/prompt_guard/README.md
+++ b/recipes/responsible_ai/prompt_guard/README.md
@@ -1,0 +1,8 @@
+## Prompt Guard Guide
+
+This guide has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/getting-started/responsible_ai/prompt_guard).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/use_cases/browser_use/agent/README.md
+++ b/recipes/use_cases/browser_use/agent/README.md
@@ -1,0 +1,8 @@
+## Browser Use Agent
+
+This recipe has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/end-to-end-use-cases/browser_use/agent).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/use_cases/coding/text2sql/README.md
+++ b/recipes/use_cases/coding/text2sql/README.md
@@ -1,0 +1,8 @@
+## Txt2Sql
+
+This recipe has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/end-to-end-use-cases/coding/text2sql).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/use_cases/customerservice_chatbots/RAG_chatbot/README.md
+++ b/recipes/use_cases/customerservice_chatbots/RAG_chatbot/README.md
@@ -1,0 +1,8 @@
+## RAG Chatbot
+
+This recipe has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/end-to-end-use-cases/customerservice_chatbots/RAG_chatbot).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/use_cases/customerservice_chatbots/messenger_chatbot/README.md
+++ b/recipes/use_cases/customerservice_chatbots/messenger_chatbot/README.md
@@ -1,0 +1,8 @@
+## Messenger Chatbot
+
+This recipe has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/end-to-end-use-cases/customerservice_chatbots/messenger_chatbot).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/use_cases/customerservice_chatbots/whatsapp_chatbot/README.md
+++ b/recipes/use_cases/customerservice_chatbots/whatsapp_chatbot/README.md
@@ -1,0 +1,8 @@
+## WhatsApp Chatbot
+
+This recipe has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/end-to-end-use-cases/customerservice_chatbots/whatsapp_chatbot).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/use_cases/email_agent/README.md
+++ b/recipes/use_cases/email_agent/README.md
@@ -1,0 +1,8 @@
+## Email Agent
+
+This recipe has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/end-to-end-use-cases/email_agent).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/use_cases/end2end-recipes/RAFT-Chatbot/README.md
+++ b/recipes/use_cases/end2end-recipes/RAFT-Chatbot/README.md
@@ -1,0 +1,8 @@
+## RAFT-Chatbot
+
+This recipe has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/end-to-end-use-cases/RAFT-Chatbot).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/use_cases/github_triage/README.md
+++ b/recipes/use_cases/github_triage/README.md
@@ -1,0 +1,8 @@
+## GitHub Triage
+
+This recipe has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/end-to-end-use-cases/github_triage).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!

--- a/recipes/use_cases/multilingual/README.md
+++ b/recipes/use_cases/multilingual/README.md
@@ -1,0 +1,8 @@
+## Multilingual
+
+This recipe has moved to a new directory, [here](https://github.com/meta-llama/llama-cookbook/tree/main/end-to-end-use-cases/multilingual).
+
+Please update any bookmarks and scripts to point to this new location.
+
+
+Thank you!


### PR DESCRIPTION
# What does this PR do?

This PRs will create the old`/recipes` to only add readme files pointing to the new location of the recipes and getting-started guides.

This is to ensure that any existing links will not be broken and can point the user to the correct location.
